### PR TITLE
remove define before use

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -204,9 +204,6 @@
     // use vars if you declared them
     "no-unused-vars": [2, {"vars": "local", "args": "after-used"}],
 
-    // disallow foo = 1; var foo
-    "no-use-before-define": 2,
-
     // so many callbacks, so little time to handle them...
     "handle-callback-err": 0,
 


### PR DESCRIPTION
I know this is a pretty useful rule but (there's always a but:))

So I cannot write code like this (with this rule turned on)

```
function haters() {
   return gonna(onHate);

   function onHate(err) {

   }
};
```

Now I have to to this:

```
function haters() {
   function onHate(err) {

   }
   return gonna(onHate);
}
```
